### PR TITLE
Make Ubuntu Resolute Chiseled the default

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,12 @@
 {
   "name": "PowerShell Runtime Containers",
-  "image": "mcr.microsoft.com/devcontainers/dotnet:1-10.0-preview-trixie-slim", //Trixie needed for podman/buildah updates
+  "image": "mcr.microsoft.com/devcontainers/dotnet:1-10.0", //Trixie needed for podman/buildah updates
   "privileged": true,
   "hostRequirements": {
     "cpus": 4 // To build containers in parallel and match the GitHub Actions environment
   },
   "initializeCommand": "docker images -a", //To see what images are cached on the devcontainer or host
-  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y podman skopeo && sudo mount --make-rshared / && sudo ln -s /usr/bin/podman /usr/bin/docker",
+  "postCreateCommand": "sudo rm /etc/apt/sources.list.d/yarn.list;sudo apt-get update && sudo apt-get install -y podman skopeo crun && sudo mount --make-rshared / && sudo ln -s /usr/bin/podman /usr/bin/docker",
   "containerEnv": {
     "PODMAN_IGNORE_CGROUPSV1_WARNING": "true"
   },

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -34,7 +34,7 @@ jobs:
       ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install Podman
       run: |

--- a/Containers/Distroless/Containerfile
+++ b/Containers/Distroless/Containerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 #These args will vary based on the build. This is a multi-arch build
 ARG DIST=noble-chiseled
 ARG PS_VERSION=7.5.1
@@ -20,6 +22,8 @@ ARG TAG=$PS_VERSION-$DIST-$TARGETARCH
 FROM --platform=$BUILDPLATFORM alpine AS install-powershell
 ARG PS_INSTALL_FOLDER PS_VERSION PS_PACKAGE_BASE_URL TARGETARCH TARGETPLATFORM
 #Passed thru so it can reach the configure stage
+RUN mkdir -p $PS_INSTALL_FOLDER
+WORKDIR $PS_INSTALL_FOLDER
 RUN <<SCRIPT
 if [ "${TARGETARCH}" = "amd64" ]; then
 	PSARCH="x64"
@@ -31,28 +35,24 @@ else
 fi
 
 #Fetch and extract the appropriate zip
+
+echo "Fetching PowerShell $PS_VERSION for $TARGETARCH from $PS_PACKAGE_BASE_URL-$PSARCH.tar.gz"
 wget -O /tmp/linux.tar.gz $PS_PACKAGE_BASE_URL-$PSARCH.tar.gz
-mkdir -p $PS_INSTALL_FOLDER
 echo "Extracting to $PS_INSTALL_FOLDER"
 tar zxf /tmp/linux.tar.gz -C $PS_INSTALL_FOLDER
 chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh
 chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh.dll
-SCRIPT
 
-
-#Cleanup unnecessary items
-WORKDIR $PS_INSTALL_FOLDER
-RUN <<SCRIPT
 # Unnecessary Modules for runtime
 rm -rf Schemas Modules/PowerShellGet Modules/Microsoft.PowerShell.PSResourceGet Modules/PackageManagement Modules/PSReadLine
 #Unnecessary localization
 rm -rf zh-Hans zh-Hant cs de es fr it ja ko pl pt-BR tr ru _manifest ref
 
 # Additional Unnecessary Extras
-rm Microsoft.PowerShell.*.xml
-rm ThirdPartyNotices.txt
-rm System.Directory*.dll System.Data.SqlClient.dll System.Data.Odbc.dll
-rm System.Drawing.Common.dll System.Speech.dll
+rm -v Microsoft.PowerShell.*.xml
+rm -v ThirdPartyNotices.txt
+rm -v System.Directory*.dll System.Data.SqlClient.dll System.Data.Odbc.dll
+rm -v System.Drawing.Common.dll System.Speech.dll
 SCRIPT
 
 #STAGE: Configure PowerShell

--- a/README.MD
+++ b/README.MD
@@ -37,13 +37,15 @@ The default distro is [.NET Chiseled](https://github.com/dotnet/dotnet-docker/bl
 * `X.Y` - latest feature version. For example: `7.4` is latest 7.4.Z version.
 * `7.X.Y` - "pinned" version to the version you specify. For example: `7.4.2` will always be `7.4.2`
 * `azurelinux3.0-distroless` - latest stable version using [.NET Azure Linux 3.0 distroless](https://github.com/dotnet/dotnet-docker/blob/main/documentation/azurelinux.md)
-* `noble-chiseled` - latest stable version using 
+* `dotnet-chiseled` - latest stable version using latest .NET Chiseled
+* `noble-chiseled` - latest stable version using .NET Chiseled for Ubuntu 24.04 (Noble)
+* `resolute-chiseled` - latest stable using .NET Chiseled for Ubuntu 26.04 (Resolute)
 
 > [!TIP]
-There are direct tags you can pin to a specific version and architecture. These tags should be considered relatively stable but not immutable, as changes to the image build process or bugfixes may be required, but the PowerShell version specified will remain the same.
+Tags should not be considered immutable and are provided for convenience. I reserve the right to make breaking changes to any tag at any time. You should pin specific SHA versions if stability and predictability is a need in your environment, and to avoid unlikely but possible supply chain attacks to this repository. That said, most tags should remain relatively stable, e.g. 7.4 will always be the latest version of 7.4, but the underlying container architecture might undergo minor changes.
 
 ## 📦 Bundling
-To create new container applications, define a new dockerfile that bundles your script.
+To create new container applications, define a new `Dockerfile` or `Containerfile` that bundles your script and any modules or components your script requires.
 
 * [Standalone Script Example](Examples/Script/README.MD)
 * [Script with Modules Example](Examples/ScriptWithModules/README.MD)
@@ -51,7 +53,9 @@ To create new container applications, define a new dockerfile that bundles your 
 
 ## About These Containers
 
-These images run the self-contained version of PowerShell on top of the dotnet/runtime-deps container, with some additional features removed to reduce size:
+These images run the self-contained version of PowerShell on top of distroless container bases to minimize size and security surface.
+
+### Removed Features for size/security:
 1. PowerShellGet/PSResourceGet/PackageManagement removed (you should bundle modules into your container directly)
 1. Help Removed
 1. PSReadline Removed (this is not meant for interactive use)
@@ -71,3 +75,4 @@ While fxdependent is smaller, the self-contained images contain precompliation t
 ## Updates
 
 There are plans to auto-generate new images upon new PowerShell release within 24 hours, potentially as soon as a release is posted.
+For now releases are generated to powershell-test, smoke tested manually, and then graduated to powershell

--- a/build.ps1
+++ b/build.ps1
@@ -8,6 +8,7 @@ param(
 	[SemanticVersion]$minimumPSVersion = '7.4',
 	#For now, our build process is the same for both. This may change in the future
 	$Distributions = @(
+		'resolute-chiseled'
 		'noble-chiseled'
 		'azurelinux3.0-distroless'
 	),
@@ -100,6 +101,9 @@ function Get-AdditionalTags {
 		#Distro tag processing
 		if ($latestTag.Add($distribution)) {
 			$additionalTags += $distribution
+		}
+		if ($distribution -match 'chiseled$' -and $latestTag.Add('dotnet-chiseled')) {
+			$additionalTags += 'resolute'
 		}
 	}
 	if ($version.PrereleaseLabel) {
@@ -271,7 +275,7 @@ tag_name,
 },
 name,
 assets
-| Where-Object Version -GT $minimumPSVersion
+| Where-Object Version -GE $minimumPSVersion
 | Sort-Object Version -Descending
 
 #These releases are what we will actually build and push, but we still need to "process" all releases to accurate determine the rollup tags like 7, latest, lts, etc.
@@ -323,6 +327,10 @@ foreach ($release in $pwshReleases) {
 		}
 		if ($skipVersions -contains $powershellTag) {
 			Write-Verbose "🔨❌ Skipping known bad image $powershellTag"
+			continue
+		}
+		if ($version -lt '7.6.0' -and $distribution -eq 'resolute-chiseled') {
+			Write-Verbose "🔨❌ Skipping version $version for distribution $distribution because resolute isn't supported below .NET 10"
 			continue
 		}
 

--- a/build.ps1
+++ b/build.ps1
@@ -103,7 +103,7 @@ function Get-AdditionalTags {
 			$additionalTags += $distribution
 		}
 		if ($distribution -match 'chiseled$' -and $latestTag.Add('dotnet-chiseled')) {
-			$additionalTags += 'resolute'
+			$additionalTags += 'dotnet-chiseled'
 		}
 	}
 	if ($version.PrereleaseLabel) {


### PR DESCRIPTION
Set Ubuntu Resolute Chiseled as the default distribution for PowerShell containers and update the README to reflect this change. Adjust the Dockerfile and build scripts accordingly to support the new default. Upgrade the actions/checkout version for improved functionality.